### PR TITLE
修复只读模式下，双击仍然可以编辑节点的问题

### DIFF
--- a/src/runtime/input.js
+++ b/src/runtime/input.js
@@ -61,7 +61,7 @@ define(function(require, exports, module) {
             });
 
             minder.on('dblclick', function() {
-                if (minder.getSelectedNode()) {
+                if (minder.getSelectedNode() && minder._status !== 'readonly') {
                     editText();
                 }
             });


### PR DESCRIPTION
minder.disable();的时候双击节点应该是不能够编辑的
