### PR TITLE
Allow hyperlinks for localhost or Lan hosts

### DIFF
--- a/ui/dialog/hyperlink/hyperlink.ctrl.js
+++ b/ui/dialog/hyperlink/hyperlink.ctrl.js
@@ -1,7 +1,7 @@
 angular.module('kityminderEditor')
     .controller('hyperlink.ctrl', function ($scope, $modalInstance, link) {
 
-        $scope.R_URL = /(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?/;
+        $scope.R_URL = /(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)*([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?/;
 
         $scope.url = link.url || '';
         $scope.title = link.title || '';


### PR DESCRIPTION
Allow hyperlinks for localhost or Lan hosts.
Also will allow urls like http://user:password@host.com/.