### PR TITLE
Fix invalid sources in package-lock.json

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
 	<link rel="stylesheet" href="../bower_components/codemirror/lib/codemirror.css" />
 	<link rel="stylesheet" href="../bower_components/hotbox/hotbox.css" />
-	<link rel="stylesheet" href="../node_modules/kityminder-core/dist/kityminder.core.css" />
+	<link rel="stylesheet" href="../bower_components/kityminder-core/dist/kityminder.core.css" />
 	<link rel="stylesheet" href="../bower_components/color-picker/dist/color-picker.min.css" />
 	<!-- endbower -->
 
@@ -62,11 +62,11 @@
 <script src="../bower_components/codemirror/addon/mode/overlay.js"></script>
 <script src="../bower_components/codemirror/mode/gfm/gfm.js"></script>
 <script src="../bower_components/angular-ui-codemirror/ui-codemirror.js"></script>
-<script src="../bower_components/marked/lib/marked.js"></script>
+<script src="../bower_components/marked/marked.min.js"></script>
 <script src="../bower_components/kity/dist/kity.min.js"></script>
 <script src="../bower_components/hotbox/hotbox.js"></script>
 <script src="../bower_components/json-diff/json-diff.js"></script>
-<script src="../node_modules/kityminder-core/dist/kityminder.core.min.js"></script>
+<script src="../bower_components/kityminder-core/dist/kityminder.core.min.js"></script>
 <script src="../bower_components/color-picker/dist/color-picker.min.js"></script>
 <!-- endbower -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -747,7 +747,7 @@
     },
     "cli-color": {
       "version": "0.1.7",
-      "resolved": "http://registry.npm.baidu-int.com/cli-color/-/cli-color-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
       "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
       "requires": {
         "es5-ext": "0.8.x"
@@ -1039,7 +1039,7 @@
     },
     "difflib": {
       "version": "0.2.4",
-      "resolved": "http://registry.npm.baidu-int.com/difflib/-/difflib-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
       "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
       "requires": {
         "heap": ">= 0.2.0"
@@ -1056,7 +1056,7 @@
     },
     "dreamopt": {
       "version": "0.6.0",
-      "resolved": "http://registry.npm.baidu-int.com/dreamopt/-/dreamopt-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
       "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
       "requires": {
         "wordwrap": ">=0.0.2"
@@ -1212,7 +1212,7 @@
     },
     "es5-ext": {
       "version": "0.8.2",
-      "resolved": "http://registry.npm.baidu-int.com/es5-ext/-/es5-ext-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
       "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
     },
     "escape-html": {
@@ -3081,7 +3081,7 @@
     },
     "heap": {
       "version": "0.2.6",
-      "resolved": "http://registry.npm.baidu-int.com/heap/-/heap-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
       "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "hoek": {
@@ -3541,7 +3541,7 @@
     },
     "json-diff": {
       "version": "0.5.2",
-      "resolved": "http://registry.npm.baidu-int.com/json-diff/-/json-diff-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.2.tgz",
       "integrity": "sha512-N7oapTQdD4rLMUtA7d1HATCPY/BpHuSNL1mhvIuoS0u5NideDvyR+gB/ntXB7ejFz/LM0XzPLNUJQcC68n5sBw==",
       "requires": {
         "cli-color": "~0.1.6",
@@ -3625,12 +3625,12 @@
     },
     "kity": {
       "version": "2.0.4",
-      "resolved": "http://registry.npm.baidu-int.com/kity/-/kity-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/kity/-/kity-2.0.4.tgz",
       "integrity": "sha512-u6jPit9N44gPTMzB7EiX3szurI7JB6HPswJESQiS0UnrNiceOeLxGRAm0mgGRuRnkGXwmA3Pzn7hZ1rauINpOA=="
     },
     "kityminder-core": {
       "version": "1.4.50",
-      "resolved": "http://registry.npm.baidu-int.com/kityminder-core/-/kityminder-core-1.4.50.tgz",
+      "resolved": "https://registry.npmjs.org/kityminder-core/-/kityminder-core-1.4.50.tgz",
       "integrity": "sha512-HMXTLOqpyvnDVZiRJOt1TghF7hiWWxm2NKc40L9IL31Ev5Rkm4CHyY2m+1RP3YLHW00MWH/IX0KETuYIXnToTw==",
       "requires": {
         "json-diff": "^0.5.2",
@@ -4854,7 +4854,7 @@
     },
     "seajs": {
       "version": "2.3.0",
-      "resolved": "http://registry.npm.baidu-int.com/seajs/-/seajs-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/seajs/-/seajs-2.3.0.tgz",
       "integrity": "sha1-+inQ/h/NQsAYoq61ZwcDVGBZbIs="
     },
     "semver": {


### PR DESCRIPTION
`package-lock.json` 中的部份依赖的源似乎是百度的私有库 http://registry.npm.baidu-int.com，无法访问，修改为 https://registry.npmjs.org 后可用。